### PR TITLE
Fix encoding/decoding of URL

### DIFF
--- a/lib/calendars.js
+++ b/lib/calendars.js
@@ -217,9 +217,7 @@ export let listCalendarObjects = co.wrap(function* (calendar, options) {
          ${calendar.account.credentials.username}`);
 
   let results = yield listCalendarObjectsEtags(calendar, options);
-  options.hrefs = results
-    .filter((res) => ensureIsUri(res.href))
-    .map((res) => res.href);
+  options.hrefs = results.map((res) => res.href);
 
   debug('Got the following etags:');
   debug(options.hrefs);
@@ -254,9 +252,8 @@ export let syncCalendarObjects = co.wrap(function* (calendar, options) {
 
   // Compare local calendar objects with remote calendar objects
   const localEvents = calendar.objects;
-  const remoteEvents = remoteCalendarObjects.filter((obj) =>
-    ensureIsUri(obj.href)
-  );
+  const remoteEvents = remoteCalendarObjects;
+
   remoteEvents.forEach((remoteEvent) => {
     // Check if remote event already exists locally
     const localEvent = localEvents.find((localEvent) =>
@@ -364,7 +361,7 @@ export let multigetCalendarObjects = co.wrap(function* (calendar, options) {
         { name: 'calendar-data', namespace: ns.CALDAV },
       ],
       depth: 1,
-      hrefs: hrefBatch,
+      hrefs: hrefBatch.map(ensureEncodedPath),
     });
 
     // Make request to retrieve calendar data
@@ -477,21 +474,6 @@ let extractPathFromSpec = (aSpec) => {
 };
 
 /**
- * This is called to create an encoded path from a unencoded path OR
- * encoded full url
- *
- * @param aString {string} un-encoded path OR encoded uri spec.
- */
-const ensureEncodedPath = (aString) => {
-  if (aString.charAt(0) != '/') {
-    aString = ensureDecodedPath(aString);
-  }
-  let uriComponents = aString.split('/');
-  uriComponents = uriComponents.map(encodeURIComponent);
-  return uriComponents.join('/');
-};
-
-/**
  * This is called to get a decoded path from an encoded path or uri spec.
  *
  * @param {string} aString - Represents either a path
@@ -558,7 +540,6 @@ let webdavSync = co.wrap(function* (calendar, options) {
   // Results contains new, modified or deleted objects.
   // Normalize and clean-up results
   result.responses
-    .filter((res) => ensureIsUri(res.href))
     .forEach((res) => {
       res.href = ensureDecodedPath(res.href);
 
@@ -606,7 +587,7 @@ let webdavSync = co.wrap(function* (calendar, options) {
         { name: 'calendar-data', namespace: ns.CALDAV },
       ],
       depth: 1,
-      hrefs: newUpdatedHrefsChunk,
+      hrefs: newUpdatedHrefsChunk.map(ensureEncodedPath),
     });
 
     try {
@@ -636,9 +617,7 @@ let webdavSync = co.wrap(function* (calendar, options) {
   // Calendar objects array will contain all new, modified and deleted events
   calendar.objects = [];
   results.forEach(function (response) {
-    if (ensureIsUri(response.href)) {
-      response.href = ensureDecodedPath(response.href);
-    } else return;
+    response.href = ensureDecodedPath(response.href);
 
     if (!response.props.calendarData || !response.props.calendarData.length)
       return;
@@ -691,7 +670,7 @@ async function listCalendarObjectsInSeries_(hrefs, options, calendar) {
         { name: 'calendar-data', namespace: ns.CALDAV },
       ],
       depth: 1,
-      hrefs: [href],
+      hrefs: [href].map(ensureEncodedPath),
     });
 
     // Send request

--- a/lib/calendars.js
+++ b/lib/calendars.js
@@ -503,32 +503,24 @@ const ensureDecodedPath = (aString) => {
     aString = extractPathFromSpec(aString);
   }
 
-  let uriComponents = aString.split('/');
-  for (let i = 0; i < uriComponents.length; i++) {
-    try {
-      uriComponents[i] = decodeURIComponent(uriComponents[i]);
-    } catch (e) {
-      debug(
-        'CalDAV: Exception decoding path ' +
-          aString +
-          ', segment: ' +
-          uriComponents[i]
-      );
-    }
+  try {
+    return decodeURI(aString);
   }
-  return uriComponents.join('/');
+  catch(e) {
+    // This is not necessarily an error as decodeURIComponent 
+    // might throw an error if the string is already decoded.
+    return aString;
+  }
 };
 
-const ensureIsUri = (aString) => {
-  try {
-    if (!aString || !aString.length) return false;
-    decodeURIComponent(aString);
-    return true;
-  } catch (e) {
-    debug('CalDAV: Invalid URL string: ' + aString);
-    return false;
-  }
+/**
+ * This is called to get an encoded path from a path or uri spec.
+ */
+const ensureEncodedPath = (aString) => {
+  const path = ensureDecodedPath(aString);
+  return encodeURI(path);
 };
+
 
 let basicSync = co.wrap(function* (calendar, options) {
   let sync = yield webdav.isCollectionDirty(calendar, options);

--- a/lib/fuzzy_url_equals.js
+++ b/lib/fuzzy_url_equals.js
@@ -14,7 +14,15 @@ export default function fuzzyUrlEquals(one, other) {
 
 function isEncoded(uri) {
   uri = uri || '';
-  return uri !== decodeURIComponent(uri);
+  try {
+    return uri !== decodeURIComponent(uri);
+  }
+  catch (e) {
+    // If the URL cannot be decoded, it is probably not encoded
+    // For example if the URL is 'http://example.com/%ZZ'
+    // decodeURIComponent throws an error
+    return false;
+  }
 }
 
 function fullyDecodeURI(uri) {


### PR DESCRIPTION
If we decode URIs when we get them, we _have to_ re-encode them before performing the multiget, otherwise we might be using a wrong URI.

Notice that this does not matter if the event URI does not contain invalid URI characters. If it does, however, we need to either use the URI as it comes from previous requests, or re-encode it if we decode it first.