### PR TITLE
Remove all encoding/decoding logic from hrefs

### DIFF
--- a/dav.js
+++ b/dav.js
@@ -1210,7 +1210,7 @@ var multigetCalendarObjects = _co["default"].wrap( /*#__PURE__*/_regenerator["de
               namespace: ns.CALDAV
             }],
             depth: 1,
-            hrefs: hrefBatch.map(ensureEncodedPath)
+            hrefs: hrefBatch
           }); // Make request to retrieve calendar data
           _context8.t0 = responses.push;
           _context8.t1 = responses;
@@ -1356,53 +1356,7 @@ var syncCaldavAccount = _co["default"].wrap( /*#__PURE__*/_regenerator["default"
     }
   }, _callee11);
 }));
-
-/**
- * Extract the path from the full spec, if the regexp failed, log
- * warning and return unaltered path.
- */
 exports.syncCaldavAccount = syncCaldavAccount;
-var extractPathFromSpec = function extractPathFromSpec(aSpec) {
-  // The parsed array should look like this:
-  // a[0] = full string
-  // a[1] = scheme
-  // a[2] = everything between the scheme and the start of the path
-  // a[3] = extracted path
-  var a = aSpec.match('(https?)(://[^/]*)([^#?]*)');
-  if (a && a[3]) {
-    return a[3];
-  }
-  debug('CalDAV: Spec could not be parsed, returning as-is: ' + aSpec);
-  return aSpec;
-};
-
-/**
- * This is called to get a decoded path from an encoded path or uri spec.
- *
- * @param {string} aString - Represents either a path
- *                           or a full uri that needs to be decoded.
- * @return {string} A decoded path.
- */
-var ensureDecodedPath = function ensureDecodedPath(aString) {
-  if (aString.charAt(0) != '/') {
-    aString = extractPathFromSpec(aString);
-  }
-  try {
-    return decodeURI(aString);
-  } catch (e) {
-    // This is not necessarily an error as decodeURIComponent 
-    // might throw an error if the string is already decoded.
-    return aString;
-  }
-};
-
-/**
- * This is called to get an encoded path from a path or uri spec.
- */
-var ensureEncodedPath = function ensureEncodedPath(aString) {
-  var path = ensureDecodedPath(aString);
-  return encodeURI(path);
-};
 var basicSync = _co["default"].wrap( /*#__PURE__*/_regenerator["default"].mark(function _callee12(calendar, options) {
   var sync;
   return _regenerator["default"].wrap(function _callee12$(_context12) {
@@ -1464,8 +1418,6 @@ var webdavSync = _co["default"].wrap( /*#__PURE__*/_regenerator["default"].mark(
           }); // Results contains new, modified or deleted objects.
           // Normalize and clean-up results
           result.responses.forEach(function (res) {
-            res.href = ensureDecodedPath(res.href);
-
             // Validate contenttype
             if ((!res.getcontenttype || res.getcontenttype === 'text/plain') && res.href && res.href.endsWith('.ics')) {
               // If there is no content-type (iCloud) or text/plain was passed
@@ -1511,7 +1463,7 @@ var webdavSync = _co["default"].wrap( /*#__PURE__*/_regenerator["default"].mark(
               namespace: ns.CALDAV
             }],
             depth: 1,
-            hrefs: newUpdatedHrefsChunk.map(ensureEncodedPath)
+            hrefs: newUpdatedHrefsChunk
           });
           _context13.prev = 15;
           _context13.t0 = results.push;
@@ -1558,7 +1510,6 @@ var webdavSync = _co["default"].wrap( /*#__PURE__*/_regenerator["default"].mark(
           // Calendar objects array will contain all new, modified and deleted events
           calendar.objects = [];
           results.forEach(function (response) {
-            response.href = ensureDecodedPath(response.href);
             if (!response.props.calendarData || !response.props.calendarData.length) return;
 
             // Push new and modified events
@@ -1631,7 +1582,7 @@ function _listCalendarObjectsInSeries_() {
                 namespace: ns.CALDAV
               }],
               depth: 1,
-              hrefs: [href].map(ensureEncodedPath)
+              hrefs: [href]
             }); // Send request
             result = void 0;
             _context14.prev = 6;
@@ -2959,7 +2910,7 @@ var traverse = {
     });
   },
   href: function href(node) {
-    return decodeURIComponent(childNodes(node)[0].nodeValue);
+    return childNodes(node)[0].nodeValue;
   },
   status: function status(node) {
     return decodeURIComponent(childNodes(node)[0].nodeValue);
@@ -2994,7 +2945,6 @@ function traverseChild(node, childNode, childspec, result) {
   }
   var localName = (0, _camelize["default"])(childNode.localName, '-');
   if (!(localName in childspec)) {
-    debug('Unexpected node of type ' + localName + ' encountered while ' + 'parsing ' + node.localName + ' node!');
     var value = childNode.textContent;
     if (localName in result) {
       if (!Array.isArray(result[localName])) {

--- a/lib/calendars.js
+++ b/lib/calendars.js
@@ -361,7 +361,7 @@ export let multigetCalendarObjects = co.wrap(function* (calendar, options) {
         { name: 'calendar-data', namespace: ns.CALDAV },
       ],
       depth: 1,
-      hrefs: hrefBatch.map(ensureEncodedPath),
+      hrefs: hrefBatch,
     });
 
     // Make request to retrieve calendar data
@@ -455,55 +455,6 @@ export let syncCaldavAccount = co.wrap(function* (account, options = {}) {
   return account;
 });
 
-/**
- * Extract the path from the full spec, if the regexp failed, log
- * warning and return unaltered path.
- */
-let extractPathFromSpec = (aSpec) => {
-  // The parsed array should look like this:
-  // a[0] = full string
-  // a[1] = scheme
-  // a[2] = everything between the scheme and the start of the path
-  // a[3] = extracted path
-  let a = aSpec.match('(https?)(://[^/]*)([^#?]*)');
-  if (a && a[3]) {
-    return a[3];
-  }
-  debug('CalDAV: Spec could not be parsed, returning as-is: ' + aSpec);
-  return aSpec;
-};
-
-/**
- * This is called to get a decoded path from an encoded path or uri spec.
- *
- * @param {string} aString - Represents either a path
- *                           or a full uri that needs to be decoded.
- * @return {string} A decoded path.
- */
-const ensureDecodedPath = (aString) => {
-  if (aString.charAt(0) != '/') {
-    aString = extractPathFromSpec(aString);
-  }
-
-  try {
-    return decodeURI(aString);
-  }
-  catch(e) {
-    // This is not necessarily an error as decodeURIComponent 
-    // might throw an error if the string is already decoded.
-    return aString;
-  }
-};
-
-/**
- * This is called to get an encoded path from a path or uri spec.
- */
-const ensureEncodedPath = (aString) => {
-  const path = ensureDecodedPath(aString);
-  return encodeURI(path);
-};
-
-
 let basicSync = co.wrap(function* (calendar, options) {
   let sync = yield webdav.isCollectionDirty(calendar, options);
   if (!sync) {
@@ -539,23 +490,20 @@ let webdavSync = co.wrap(function* (calendar, options) {
 
   // Results contains new, modified or deleted objects.
   // Normalize and clean-up results
-  result.responses
-    .forEach((res) => {
-      res.href = ensureDecodedPath(res.href);
-
-      // Validate contenttype
-      if (
-        (!res.getcontenttype || res.getcontenttype === 'text/plain') &&
-        res.href &&
-        res.href.endsWith('.ics')
-      ) {
-        // If there is no content-type (iCloud) or text/plain was passed
-        // (iCal Server) for the resource but its name ends with ".ics"
-        // assume the content type to be text/calendar. Apple
-        // iCloud/iCal Server interoperability fix.
-        res.getcontenttype = 'text/calendar';
-      }
-    });
+  result.responses.forEach((res) => {
+    // Validate contenttype
+    if (
+      (!res.getcontenttype || res.getcontenttype === 'text/plain') &&
+      res.href &&
+      res.href.endsWith('.ics')
+    ) {
+      // If there is no content-type (iCloud) or text/plain was passed
+      // (iCal Server) for the resource but its name ends with ".ics"
+      // assume the content type to be text/calendar. Apple
+      // iCloud/iCal Server interoperability fix.
+      res.getcontenttype = 'text/calendar';
+    }
+  });
 
   let deletedHrefs = result.responses
     .filter(
@@ -587,7 +535,7 @@ let webdavSync = co.wrap(function* (calendar, options) {
         { name: 'calendar-data', namespace: ns.CALDAV },
       ],
       depth: 1,
-      hrefs: newUpdatedHrefsChunk.map(ensureEncodedPath),
+      hrefs: newUpdatedHrefsChunk,
     });
 
     try {
@@ -617,8 +565,6 @@ let webdavSync = co.wrap(function* (calendar, options) {
   // Calendar objects array will contain all new, modified and deleted events
   calendar.objects = [];
   results.forEach(function (response) {
-    response.href = ensureDecodedPath(response.href);
-
     if (!response.props.calendarData || !response.props.calendarData.length)
       return;
 
@@ -670,7 +616,7 @@ async function listCalendarObjectsInSeries_(hrefs, options, calendar) {
         { name: 'calendar-data', namespace: ns.CALDAV },
       ],
       depth: 1,
-      hrefs: [href].map(ensureEncodedPath),
+      hrefs: [href],
     });
 
     // Send request

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -106,7 +106,7 @@ let traverse = {
   },
 
   href: (node) => {
-    return decodeURIComponent(childNodes(node)[0].nodeValue);
+    return childNodes(node)[0].nodeValue;
   },
 
   status: (node) => {
@@ -145,14 +145,6 @@ function traverseChild(node, childNode, childspec, result) {
 
   let localName = camelize(childNode.localName, '-');
   if (!(localName in childspec)) {
-    debug(
-      'Unexpected node of type ' +
-        localName +
-        ' encountered while ' +
-        'parsing ' +
-        node.localName +
-        ' node!'
-    );
     let value = childNode.textContent;
     if (localName in result) {
       if (!Array.isArray(result[localName])) {

--- a/test/encoding.spec.js
+++ b/test/encoding.spec.js
@@ -1,0 +1,22 @@
+/**
+ * Encoding/decoding of URLs was removed cause there is no way to
+ * make sure encode(decode(url)) === url for each of the following URLs.
+ * This is necessary to ensure that we use the same exact href as originally
+ * provided by the server when querying for data.
+ *
+ * This test file is empty but is left here as a reminder that the encoding/decoding
+ * of URLs is not a good idea. If encoding/decoding is added back, it should
+ * pass the test encode(decode(url)) === url for each of the following URLs.
+ */
+
+const testHrefs = [
+  // https://linear.app/morgen/issue/MOR-1642/icloud-400-error
+  '/17363831/calendars/ADE37349-97D2-462F-B2F9-894D7706401D/wwwgartnercom-en-webinarscommId%3D539334%26channelId%3D17810%26srcId%3D1-4582955171%26ref%3Dbtem%26.ics',
+  '/299087925/calendars/1E40C9BC-56BA-4A00-8C90-376BD88D5D51/https%3A%252Fwww.gartner.com%252Fen%252Fwebinars%3FcommId%3D539334%26channelId%3D17810%26srcId%3D1-4582955171%26ref%3Dbtem%26.ics',
+  // https://linear.app/morgen/issue/MOR-1607/error-connecting-to-daylite
+  '/calendars/1000/calendar_category_47001/20180601T093710Z-523642597%40fe800008f4aefffe9bd1%25eth0.ics',
+  // Custom test (@ in the component)
+  '/299087925/calendars/1E40C9BC-56BA-4A00-8C90-376BD88D5D51/webinars%252Fancona%40test.com%252F123.ics',
+  // https://linear.app/morgen/issue/MOR-1009/caldav-href-encoding-issue
+  '/caldav/121DQxz7QtyAZvrLLL6V2g==/events/333159b5684440478e4e8fc8881d4827%40zoho.com.ics',
+];

--- a/test/fuzzy_url_equals.spec.js
+++ b/test/fuzzy_url_equals.spec.js
@@ -1,0 +1,20 @@
+const fuzzyUrlEquals = require('../lib/fuzzy_url_equals').default;
+
+describe('fuzzyUrlEquals', function () {
+  test('should return true for equal URLs', function () {
+    expect(fuzzyUrlEquals('http://example.com', 'http://example.com')).toBe(
+      true
+    );
+
+    expect(fuzzyUrlEquals('http://example.com', 'http://example.com/')).toBe(
+      true
+    );
+
+    expect(
+      fuzzyUrlEquals(
+        'http://example.com/test@morgen.so',
+        'http://example.com/test%40morgen.so'
+      )
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Resolves MOR-1642, also taking into account other issues we found in the past (MOR-1607 and MOR-1009).

All 3 issues linked above are caused by incorrect encoding/decoding of the hrefs. In particular we try to the following:
- Get `hrefs` as part of calendar changes
- Decode the `hrefs`
- Encode the `hrefs`
- Use the encoded `hrefs` to query the actual data.

This assumes that we can find a `decode` and `encode` functions such that `encode(decode(href)) === href` (under the assumption that queries should use the exact same href returned by the same server in the first place).
Unfortunately, finding a decode/encode pair that fulfill that condition all the times is very hard. We should therefore just use whatever is returned by the server without any attempt to normalize it.

---

Note 1: the `dav` library introduced `encodeURIComponent(href)` as part of their parser in https://github.com/lambdabaa/dav/issues/91. However, I think this is the wrong solution to the problem mentioned there. First, it does not make sense to call `decodeURIComponent` on something that is _not_ a URI component. Second, we already use `fuzzyUrlEquals` URL matching to fix this problem.

---

Note 2: Notice that this PR might break the for some existing users. In particular, if users have already in the local db an event with a _decoded_ providerId, a duplicate event will be created after this change. On the other hand, they can Resync all data to fix the problem and this seems a reasonable price to pay to fix it once and for all (hopefully). 

---

After review and merging:
- [ ] Update `dav` hash on desktop
- [ ] Port the same change to sync service and backend